### PR TITLE
t-(unified-)dpf: Include 'stdlib.h' for malloc

### DIFF
--- a/t-distribute-parallel-for-back2back/test.cpp
+++ b/t-distribute-parallel-for-back2back/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_N 25000
 

--- a/t-dpf/test.cpp
+++ b/t-dpf/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_N 25000
 

--- a/t-dpfs/test.cpp
+++ b/t-dpfs/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_N 25000
 

--- a/t-unified-distribute-parallel-for-back2back/test.cpp
+++ b/t-unified-distribute-parallel-for-back2back/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #pragma omp requires unified_shared_memory
 

--- a/t-unified-dpf/test.cpp
+++ b/t-unified-dpf/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #pragma omp requires unified_shared_memory
 

--- a/t-unified-dpfs/test.cpp
+++ b/t-unified-dpfs/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #pragma omp requires unified_shared_memory
 


### PR DESCRIPTION
* t-dpf/test.cpp: #include <stdlib.h> for malloc.
* t-unified-dpf/test.cpp: Likewise.

This silences a compiler error as 'malloc' is only defined in 'stdlib.h' (or 'cstdlib') and neither in stdio.h nor in omp.h. (Although some headers might include it.)