### PR TITLE
Remove invalid { } after '#pragma omp ... for

### DIFF
--- a/t-target-large-array/test.c
+++ b/t-target-large-array/test.c
@@ -17,9 +17,7 @@ int Test(int start, int size)
   for(i=size; i<N; i++) b[i] = -1;
 
   #pragma omp target parallel for
-  {
     for(int i=start; i<size; i++) b[i] += 1;
-  }
 
   for(i=0; i<start && errors<25; i++) {
     if (b[i] != -1) printf("%4i: before, got %d, expected %d, %d error\n", i, b[i], -1, ++errors);

--- a/t-ttdpf-nested-parallel/defines.h
+++ b/t-ttdpf-nested-parallel/defines.h
@@ -1,6 +1,6 @@
 
 #undef NESTED_PARALLEL_FOR
-#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", { \
+#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", \
 for (int idx = 0; idx < tms*th; idx++) { \
 PRE  \
 _Pragma("omp parallel for if(threads[0] > 1) num_threads(threads[0]) NESTED_PARALLEL_FOR_CLAUSES") \
@@ -13,7 +13,7 @@ _Pragma("omp parallel for schedule(static,9) if(threads[0] > 1) num_threads(thre
   X  \
 POST \
 } \
-}, VERIFY)
+, VERIFY)
 
 #undef SUMS
 #define SUMS (4)

--- a/t-ttdpf-nested-parallel/test.c
+++ b/t-ttdpf-nested-parallel/test.c
@@ -162,7 +162,7 @@ int main(void) {
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
   //
-  TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", {
+  TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)",
   for (int idx = 0; idx < tms*th; idx++) {
     double q0[1];
     double q1[1];
@@ -198,7 +198,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  }, VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.
@@ -312,7 +312,7 @@ int main(void) {
   // Test: Ensure coalesced scheduling on GPU.
   //
   if (!cpuExec) {
-    TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", {
+    TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)",
       for (int idx = 0; idx < tms*th; idx++) {
         S[idx] = 0;
         for (int i = 0; i < 96; i++) {
@@ -336,7 +336,7 @@ int main(void) {
         }
         S[idx] = tmp;
       }
-    }, VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ));
+    , VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ));
   } else {
     DUMP_SUCCESS(1);
   }

--- a/t-ttdpfs-nested-parallel/defines.h
+++ b/t-ttdpfs-nested-parallel/defines.h
@@ -1,6 +1,6 @@
 
 #undef NESTED_PARALLEL_FOR
-#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)", { \
+#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)", \
 for (int idx = 0; idx < tms*th; idx++) { \
 PRE  \
 _Pragma("omp parallel for if(threads[0] > 1) num_threads(threads[0]) NESTED_PARALLEL_FOR_CLAUSES") \
@@ -13,7 +13,7 @@ _Pragma("omp parallel for schedule(static,9) if(threads[0] > 1) num_threads(thre
   X  \
 POST \
 } \
-}, VERIFY)
+, VERIFY)
 
 #undef SUMS
 #define SUMS (4)

--- a/t-ttdpfs-nested-parallel/test.c
+++ b/t-ttdpfs-nested-parallel/test.c
@@ -157,7 +157,7 @@ int main(void) {
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
   //
-  TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)", {
+  TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)",
   for (int idx = 0; idx < tms*th; idx++) {
     double q0[1];
     double q1[1];
@@ -193,7 +193,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  }, VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.

--- a/t-unified-target-large-array/test.c
+++ b/t-unified-target-large-array/test.c
@@ -19,9 +19,7 @@ int Test(int start, int size)
   for(i=size; i<N; i++) b[i] = -1;
 
   #pragma omp target parallel for
-  {
     for(int i=start; i<size; i++) b[i] += 1;
-  }
 
   for(i=0; i<start && errors<25; i++) {
     if (b[i] != -1) printf("%4i: before, got %d, expected %d, %d error\n", i, b[i], -1, ++errors);

--- a/t-unified-ttdpf-nested-parallel/defines.h
+++ b/t-unified-ttdpf-nested-parallel/defines.h
@@ -1,6 +1,6 @@
 
 #undef NESTED_PARALLEL_FOR
-#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", { \
+#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", \
 for (int idx = 0; idx < tms*th; idx++) { \
 PRE  \
 _Pragma("omp parallel for if(threads[0] > 1) num_threads(threads[0]) NESTED_PARALLEL_FOR_CLAUSES") \
@@ -13,7 +13,7 @@ _Pragma("omp parallel for schedule(static,9) if(threads[0] > 1) num_threads(thre
   X  \
 POST \
 } \
-}, VERIFY)
+, VERIFY)
 
 #undef SUMS
 #define SUMS (4)

--- a/t-unified-ttdpf-nested-parallel/test.c
+++ b/t-unified-ttdpf-nested-parallel/test.c
@@ -164,7 +164,7 @@ int main(void) {
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
   //
-  TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", {
+  TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)",
   for (int idx = 0; idx < tms*th; idx++) {
     double q0[1];
     double q1[1];
@@ -200,7 +200,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  }, VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.
@@ -314,7 +314,7 @@ int main(void) {
   // Test: Ensure coalesced scheduling on GPU.
   //
   if (!cpuExec) {
-    TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)", {
+    TESTD("omp target teams distribute parallel for num_teams(tms) num_threads(th)",
       for (int idx = 0; idx < tms*th; idx++) {
         S[idx] = 0;
         for (int i = 0; i < 96; i++) {
@@ -338,7 +338,7 @@ int main(void) {
         }
         S[idx] = tmp;
       }
-    }, VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ));
+    , VERIFY(0, tms*th, S[i], (double) 3 * 95 * 48 ));
   } else {
     DUMP_SUCCESS(1);
   }

--- a/t-unified-ttdpfs-nested-parallel/defines.h
+++ b/t-unified-ttdpfs-nested-parallel/defines.h
@@ -1,6 +1,6 @@
 
 #undef NESTED_PARALLEL_FOR
-#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)", { \
+#define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)", \
 for (int idx = 0; idx < tms*th; idx++) { \
 PRE  \
 _Pragma("omp parallel for if(threads[0] > 1) num_threads(threads[0]) NESTED_PARALLEL_FOR_CLAUSES") \
@@ -13,7 +13,7 @@ _Pragma("omp parallel for schedule(static,9) if(threads[0] > 1) num_threads(thre
   X  \
 POST \
 } \
-}, VERIFY)
+, VERIFY)
 
 #undef SUMS
 #define SUMS (4)

--- a/t-unified-ttdpfs-nested-parallel/test.c
+++ b/t-unified-ttdpfs-nested-parallel/test.c
@@ -159,7 +159,7 @@ int main(void) {
   //
   // Test: lastprivate clause on omp target teams distribute parallel for with nested parallel.
   //
-  TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)", {
+  TESTD("omp target teams distribute parallel for dist_schedule(static,2) num_teams(tms) num_threads(th)",
   for (int idx = 0; idx < tms*th; idx++) {
     double q0[1];
     double q1[1];
@@ -195,7 +195,7 @@ int main(void) {
     }
     S[idx] += tmp;
   }
-  }, VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
+  , VERIFY(0, tms*th, S[i], (double) 2 * (N + (N/2*(N+1))) ));
 
   //
   // Test: private clause on omp target teams distribute parallel for with nested parallel.

--- a/utilities/utilities.h
+++ b/utilities/utilities.h
@@ -71,12 +71,16 @@
     printf ("Succeeded\n"); \
 }
 
+/* NOTE: If needed for the pragram 'T' needs to add '{ }'; they are not
+   added unconditionally as, e.g., for '#pragma omp ... for', no '{}'
+   are permitted.  */
+
 #define TESTD(D, T, V) { \
   int fail = 0; \
   int trial; \
   for (int trial = 0; trial < TRIALS && fail == 0; trial++) { \
     _Pragma(D) \
-     {T} \
+     T \
     V \
   } \
   if (fail) { \
@@ -86,13 +90,17 @@
   } \
 }
 
+/* NOTE: If needed for the pragram 'T' needs to add '{ }'; they are not
+   added unconditionally as, e.g., for '#pragma omp ... for', no '{}'
+   are permitted.  */
+
 #define TESTD2(D, PRE, T, POST, V) { \
   int fail = 0; \
   int trial; \
   for (int trial = 0; trial < TRIALS && fail == 0; trial++) { \
     PRE \
     _Pragma(D) \
-     {T} \
+     T \
     POST \
     V \
   } \


### PR DESCRIPTION
Issue #2

OpenMP's Worksharing-Loop Construct (for C/C++ alias 'omp for')
requires that 'for-loops' follow the directive, i.e. adding additional
{ } around the for loop is not permitted (i.e. no structured block).

	* utilities/utilities.h (TESTD, TESTD2): Remove { } around the
	usage of the second ('T') argument.
	* t-ttdpf-nested-parallel/test.c (main): Avoid { } around outer
	'for' loop, passed to TESTD.
	* t-ttdpfs-nested-parallel/defines.h (NESTED_PARALLEL_FOR): Likewise.
	* t-ttdpfs-nested-parallel/test.c (main): Likewise.
	* t-unified-ttdpf-nested-parallel/defines.h (NESTED_PARALLEL_FOR): Likewise.
	* t-unified-ttdpf-nested-parallel/test.c (main): Likewise.
	* t-unified-ttdpfs-nested-parallel/defines.h (NESTED_PARALLEL_FOR):
	* t-unified-ttdpfs-nested-parallel/test.c (main): Likewise.
	* t-target-large-array/test.c (Test): Avoid '{ }' around for after
	the '#pragma omp ... for'.