### PR TITLE
xt-td-pf/test.cpp: Include 'stdlib.h' for malloc

### DIFF
--- a/xt-td-pf/test.cpp
+++ b/xt-td-pf/test.cpp
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define MAX_N 25000
 #define SIZE 1000


### PR DESCRIPTION
* xt-td-pf/test.cpp: #include <stdlib.h> for malloc.

An omission in and a follow up to the previous pull request #3 / commit  e1a3a52f3c0133e700ba4b6ec8dec276ba187491.

Without, it fails here with: `error: 'malloc' was not declared in this scope`

@doru1004 - please apply.