### PR TITLE
Fix _Pragma: Add missing 'omp'

### DIFF
--- a/t-reduction-team/test.c
+++ b/t-reduction-team/test.c
@@ -554,7 +554,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -575,7 +575,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -597,7 +597,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -619,7 +619,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -641,7 +641,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -663,7 +663,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -684,7 +684,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -706,7 +706,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -729,7 +729,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -752,7 +752,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -775,7 +775,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -798,7 +798,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -821,7 +821,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -844,7 +844,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -867,7 +867,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -890,7 +890,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1222,7 +1222,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1243,7 +1243,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1265,7 +1265,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1287,7 +1287,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1309,7 +1309,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1331,7 +1331,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1352,7 +1352,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1374,7 +1374,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1397,7 +1397,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1420,7 +1420,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1443,7 +1443,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1466,7 +1466,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1489,7 +1489,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1512,7 +1512,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1535,7 +1535,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1558,7 +1558,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {

--- a/t-tdpf-nested-parallel/defines.h
+++ b/t-tdpf-nested-parallel/defines.h
@@ -1,7 +1,7 @@
 
 #undef NESTED_PARALLEL_FOR
 #define NESTED_PARALLEL_FOR(PRE,X,POST,VERIFY) TESTD("omp target", { \
-_Pragma("teams distribute parallel for num_teams(tms) num_threads(th)") \
+_Pragma("omp teams distribute parallel for num_teams(tms) num_threads(th)") \
 for (int idx = 0; idx < tms*th; idx++) { \
 PRE  \
 _Pragma("omp parallel for if(threads[0] > 1) num_threads(threads[0]) NESTED_PARALLEL_FOR_CLAUSES") \

--- a/t-tdpf-nested-parallel/test.c
+++ b/t-tdpf-nested-parallel/test.c
@@ -164,7 +164,7 @@ int main(void) {
   // Test: lastprivate clause on omp teams distribute parallel for with nested parallel.
   //
   TESTD("omp target", {
-  _Pragma("teams distribute parallel for num_teams(tms) num_threads(th)")
+  _Pragma("omp teams distribute parallel for num_teams(tms) num_threads(th)")
   for (int idx = 0; idx < tms*th; idx++) {
     double q0[1];
     double q1[1];
@@ -315,7 +315,7 @@ int main(void) {
   //
   if (!cpuExec) {
     TESTD("omp target", {
-      _Pragma("teams distribute parallel for num_teams(tms) num_threads(th)")
+      _Pragma("omp teams distribute parallel for num_teams(tms) num_threads(th)")
       for (int idx = 0; idx < tms*th; idx++) {
         S[idx] = 0;
         for (int i = 0; i < 96; i++) {

--- a/t-unified-reduction-team/test.c
+++ b/t-unified-reduction-team/test.c
@@ -556,7 +556,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -577,7 +577,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -599,7 +599,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -621,7 +621,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -643,7 +643,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -665,7 +665,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -686,7 +686,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -708,7 +708,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -731,7 +731,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -754,7 +754,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -777,7 +777,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -800,7 +800,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -823,7 +823,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -846,7 +846,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -869,7 +869,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -892,7 +892,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1224,7 +1224,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1245,7 +1245,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1267,7 +1267,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1289,7 +1289,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1311,7 +1311,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1333,7 +1333,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1354,7 +1354,7 @@ int main(void) {
           REDUCTION_INIT();
         },
         {
-        _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
+        _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static) REDUCTION_CLAUSES")
         REDUCTION_LOOP()
         },
         {
@@ -1376,7 +1376,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1399,7 +1399,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1422,7 +1422,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(static,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1445,7 +1445,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1468,7 +1468,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1491,7 +1491,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1514,7 +1514,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(guided,sch) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1537,7 +1537,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(dynamic) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {
@@ -1560,7 +1560,7 @@ int main(void) {
             REDUCTION_INIT();
           },
           {
-          _Pragma("teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
+          _Pragma("omp teams distribute parallel for simd num_teams(tms) thread_limit(ths) dist_schedule(static,sch) schedule(runtime) REDUCTION_CLAUSES")
           REDUCTION_LOOP()
           },
           {


### PR DESCRIPTION
	* t-reduction-team/test.c: Add missing 'omp' to '_Pragma("teams'.
	* t-tdpf-nested-parallel/defines.h: Likewise
	* t-tdpf-nested-parallel/test.c: Likewise.
	* t-unified-reduction-team/test.c: Likewise.

The compiler (with `-Wall`) complained about the unknown "#pragma teams" ...

@doru1004 - please apply.